### PR TITLE
[fix s3plugin] option to change jvm tmpdir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,3 +57,6 @@ rd_create_users: []
 # Hipchat configuration
 hipchat_token: null
 hipchat_template: /etc/rundeck/hipchat_default.ftl
+
+# Rundeck TMPDIR
+rundeck_tmpdir: /tmp/rundeck

--- a/templates/profile.j2
+++ b/templates/profile.j2
@@ -2,7 +2,7 @@ RDECK_BASE=/var/lib/rundeck
 export RDECK_BASE
 
 JAVA_CMD=java
-RUNDECK_TEMPDIR={{rundeck_tmpdir}}
+RUNDECK_TEMPDIR={{ rundeck_tmpdir }}
 
 RDECK_HTTP_PORT=4440
 RDECK_HTTPS_PORT=4443

--- a/templates/profile.j2
+++ b/templates/profile.j2
@@ -2,7 +2,7 @@ RDECK_BASE=/var/lib/rundeck
 export RDECK_BASE
 
 JAVA_CMD=java
-RUNDECK_TEMPDIR=/tmp/rundeck
+RUNDECK_TEMPDIR={{rundeck_tmpdir}}
 
 RDECK_HTTP_PORT=4440
 RDECK_HTTPS_PORT=4443


### PR DESCRIPTION
    # We need this line when using version <=2.6.11 with s3 plugin (jvm tmp 
    # partition should have in the same of dir /var/lib/rundeck/logs/rundeck/*
    # https://github.com/rundeck-plugins/webdav-logstore/issues/3
