### PR TITLE
[fix] bare variables to full var syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     url: "{{ item }}"
     dest: "/var/lib/rundeck/libext/{{ item.split('/')[-1] }}"
     mode: 0644
-  with_items: rundeck_plugins
+  with_items: "{{ rundeck_plugins }}"
   notify: restart rundeckd
 
 - name: Remove default properties file

--- a/tasks/projects.yml
+++ b/tasks/projects.yml
@@ -8,7 +8,7 @@
     RUNDECK_URL: "{{framework_server_url}}"
     RUNDECK_USER: "{{framework_server_username}}"
     RUNDECK_PASS: "{{admin_password}}"
-  with_items: rd_create_projects
+  with_items: "{{ rd_create_projects }}"
   ignore_errors: true
 
 - name: Create acl for projects
@@ -18,7 +18,7 @@
     owner: rundeck
     group: rundeck
     mode: 0640
-  with_items: rd_create_projects
+  with_items: "{{ rd_create_projects }}"
 
 - name: creating base directory for projects
   file:
@@ -27,4 +27,4 @@
     owner: rundeck
     group: rundeck
     mode: '0775'
-  with_items: rd_create_projects
+  with_items: "{{ rd_create_projects }}"


### PR DESCRIPTION
Fix deprecated bare var refs.

From 5 to 1:

`ansible-lint . |grep ^'ANSIBLE' |awk '{print$1}' |sort |uniq -c`

BEFORE:

      1 ANSIBLE0010
      4 ANSIBLE0015

AFTER:

      1 ANSIBLE0010

     OBS.: Package installs should not use latest