### PR TITLE
[feature] add feature to remove plugin/file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ rundeck_plugins:
   - "https://github.com/rundeck-plugins/rundeck-s3-log-plugin/releases/download/v1.0.0/rundeck-s3-log-plugin-1.0.0.jar"
   - "https://github.com/higanworks/rundeck-slack-incoming-webhook-plugin/releases/download/v0.3.dev/rundeck-slack-incoming-webhook-plugin-0.3.jar"
 
+rundeck_plugins_removed: []
+
 # framework.properties
 framework_server_port: 4440
 framework_server_url: "http://localhost:4440"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,13 @@
   with_items: rundeck_plugins
   notify: restart rundeckd
 
+- name: remove plugins
+  file:
+    path: "/var/lib/rundeck/libext/{{ item |d(omit) }}"
+    state: absent
+  with_items: "{{ rundeck_plugins_removed }}"
+  notify: restart rundeckd
+
 - name: Remove default properties file
   file:
     path: /etc/rundeck/rundeck-config.properties


### PR DESCRIPTION
Creating feature to remove plugins file from local storage and reload rundeck. This is useful when one plugins is upgraded and prevent rundeck load two [or more] versions of it.