### PR TITLE
Feat/overrides: add option to override system binaries on jobs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -95,3 +95,8 @@ rd_ldap:
 ## Mysql
 mysql_root_user: root
 mysql_root_password: ''
+
+# Overrides
+rundeck_defaults_path: /etc/default/rundeckd
+rundeck_overrides_dir: /overrides
+rundeck_overrides: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,11 @@
     state: directory
     owner: rundeck
 
+- include: overrides.yml
+  when: rundeck_overrides | length > 0
+  notify: restart rundeckd
+  tags: rundeck-overrides
+
 - name: rundeckd is enabled
   service:
     name: rundeckd

--- a/tasks/overrides.yml
+++ b/tasks/overrides.yml
@@ -1,0 +1,26 @@
+---
+- name: Create overrides dir
+  file:
+    name: "{{ rundeck_overrides_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Overriding binaries
+  copy:
+    content: |
+      #!/bin/bash
+      echo "{{ item.msg }}"
+      sleep "{{ item.sleep |d(1) }}"
+      exit "{{ item.exit |d(1) }}"
+    dest: "{{ rundeck_overrides_dir }}/{{ item.bin }}"
+    owner: root
+    group: root
+    mode: 0755
+  with_items: "{{ rundeck_overrides }}"
+
+- name: Modify rundeck jobs PATH env var
+  lineinfile:
+    path: "{{ rundeck_defaults_path }}"
+    line: "export PATH={{ rundeck_overrides_dir }}:$PATH"


### PR DESCRIPTION
We have a problem with jobs not using virtualenv, so I created this option to "disable" pip on every job to force everyone to use a virtualenv